### PR TITLE
Removed Author Blocks as per Quinoa PR 146

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      src/CMakeLists.txt
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Build quinoa third-party Libraries
 #

--- a/docker/alpine
+++ b/docker/alpine
@@ -2,7 +2,6 @@
 # vim: filetype=dockerfile:
 #
 # \file      docker/alpine
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Dockerfile for testing the third-party libraries build for Quinoa
 #

--- a/docker/debian
+++ b/docker/debian
@@ -2,7 +2,6 @@
 # vim: filetype=dockerfile:
 #
 # \file      docker/debian
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Dockerfile for testing the third-party libraries build for Quinoa
 #


### PR DESCRIPTION
As per discussion in quinoacomputing/quinoa#146, removing author blocks to promote
more traditional open source coding model and practices