### PR TITLE
Enable ROOT build in debian docker image

### DIFF
--- a/docker/alpine
+++ b/docker/alpine
@@ -8,7 +8,7 @@
 ################################################################################
 
 FROM alpine:latest
-RUN apk update && apk add autoconf automake libtool bash grep m4 perl zlib-dev git cmake make gfortran gcc g++ libx11-dev libxpm-dev libxft-dev libxext-dev python
+RUN apk update && apk add autoconf automake libtool bash grep m4 perl zlib-dev git cmake make gfortran gcc g++
 
 ADD https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz /openmpi/
 RUN cd /openmpi/ && tar xzf openmpi-2.0.2.tar.gz && cd openmpi-2.0.2 && ./configure --enable-shared --disable-static --enable-mpi-cxx --prefix=/opt/openmpi && make -sj$(grep -c processor /proc/cpuinfo) install
@@ -27,4 +27,4 @@ USER quinoa
 WORKDIR /home/quinoa
 
 RUN git clone --recursive https://github.com/quinoacomputing/quinoa-tpl.git
-RUN cd quinoa-tpl && mkdir -p build && cd build && cmake -DENABLE_ROOT=on .. && make -sj$(grep -c processor /proc/cpuinfo)
+RUN cd quinoa-tpl && mkdir -p build && cd build && cmake .. && make -sj$(grep -c processor /proc/cpuinfo)

--- a/docker/alpine
+++ b/docker/alpine
@@ -8,7 +8,7 @@
 ################################################################################
 
 FROM alpine:latest
-RUN apk update && apk add autoconf automake libtool bash grep m4 perl zlib-dev git cmake make gfortran gcc g++
+RUN apk update && apk add autoconf automake libtool bash grep m4 perl zlib-dev git cmake make gfortran gcc g++ libx11-dev libxpm-dev libxft-dev libxext-dev python
 
 ADD https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz /openmpi/
 RUN cd /openmpi/ && tar xzf openmpi-2.0.2.tar.gz && cd openmpi-2.0.2 && ./configure --enable-shared --disable-static --enable-mpi-cxx --prefix=/opt/openmpi && make -sj$(grep -c processor /proc/cpuinfo) install

--- a/docker/alpine
+++ b/docker/alpine
@@ -27,4 +27,4 @@ USER quinoa
 WORKDIR /home/quinoa
 
 RUN git clone --recursive https://github.com/quinoacomputing/quinoa-tpl.git
-RUN cd quinoa-tpl && mkdir -p build && cd build && cmake .. && make -sj$(grep -c processor /proc/cpuinfo)
+RUN cd quinoa-tpl && mkdir -p build && cd build && cmake -DENABLE_ROOT=on .. && make -sj$(grep -c processor /proc/cpuinfo)

--- a/docker/debian
+++ b/docker/debian
@@ -8,7 +8,7 @@
 ################################################################################
 
 FROM debian:testing
-RUN apt-get update -y && apt-get install -y git autoconf cmake gfortran g++ libopenmpi-dev m4 zlib1g-dev
+RUN apt-get update -y && apt-get install -y git autoconf cmake gfortran g++ libopenmpi-dev m4 zlib1g-dev libx11-dev libxpm-dev libxft-dev libxext-dev python
 
 RUN adduser --gecos "" --disabled-password quinoa
 USER quinoa

--- a/docker/debian
+++ b/docker/debian
@@ -15,4 +15,4 @@ USER quinoa
 WORKDIR /home/quinoa
 
 RUN git clone --recursive https://github.com/quinoacomputing/quinoa-tpl.git
-RUN cd quinoa-tpl && mkdir -p build && cd build && cmake .. && make -sj$(grep -c processor /proc/cpuinfo)
+RUN cd quinoa-tpl && mkdir -p build && cd build && cmake -DENABLE_ROOT=on .. && make -sj$(grep -c processor /proc/cpuinfo)


### PR DESCRIPTION
This is used in TC, testing the TPL builds.

Not enabling the same for the alpine image, because TBB (as part of ROOT) does not build on alpine.