### PR TITLE
Enable BackwardCpp to be turned off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,11 +401,14 @@ if(ENABLE_ROOT)
 endif()
 
 # Detect backward-cpp
-find_package(BackwardCpp)
-if(BACKWARDCPP_FOUND)
-  set(backwardcpp "")
-else()
-  set(backwardcpp "backwardcpp")
+set(ENABLE_BACKWARDCPP ON CACHE BOOL "Enable BackwardCpp")
+if (ENABLE_BACKWARDCPP)
+  find_package(BackwardCpp)
+  if(BACKWARDCPP_FOUND)
+    set(backwardcpp "")
+  else()
+    set(backwardcpp "backwardcpp")
+  endif()
 endif()
 
 # Detect highwayhash


### PR DESCRIPTION
The default is _on_, i.e., no change to by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa-tpl/26)
<!-- Reviewable:end -->
